### PR TITLE
remove lazystream binary from repo, get from tagged release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,12 @@ RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux
 ADD guide2go /usr/bin/guide2go
 
 # Add lazystream
-ADD lazystream /usr/bin/lazystream
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.9.4/lazystream-v1.9.4-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+    tar xzf lazystream.tar.gz; \
+    mv lazystream/lazystream /usr/bin/lazystream; \
+    rm lazystream.tar.gz; \
+    rm -rf lazystream/
+
 ADD cronjob.sh /
 ADD entrypoint.sh /
 ADD sample_cron.txt /


### PR DESCRIPTION
It's better to get this from a tagged release vs have a binary commited to the repo. I noticed guide2go doesn't have any release binaries, so I'll leave that for now