### PR TITLE
m3u needs to be updated via API

### DIFF
--- a/cronjob.sh
+++ b/cronjob.sh
@@ -90,6 +90,8 @@ if [ "$use_xTeveAPI" = "yes" ]; then
 	if [ -z "$xTeveIP" ]; then
 		echo "no xTeve credentials provided"
 	else
+		curl -X POST -d '{"cmd":"update.m3u"}' http://$xTeveIP:$xTevePORT/api/
+		sleep 1
 		curl -X POST -d '{"cmd":"update.xmltv"}' http://$xTeveIP:$xTevePORT/api/
 		sleep 1
 		curl -X POST -d '{"cmd":"update.xepg"}' http://$xTeveIP:$xTevePORT/api/


### PR DESCRIPTION
without this, xTeVe won't be referencing the latest stream links and when the game is chosen in Plex, it will fail.

```
2020/03/02 17:11:01 [xTeVe] Buffer:                true [ffmpeg]
2020/03/02 17:11:01 [xTeVe] Buffer Size:           5120 KB
2020/03/02 17:11:01 [xTeVe] Channel Name:          Lazystream: NHL 1
2020/03/02 17:11:01 [xTeVe] Client User-Agent:     Lavf/58.27.104
2020/03/02 17:11:02 [xTeVe] Streaming Status:      Playlist: nhl - Tuner: 1 / 4
2020/03/02 17:11:02 [xTeVe] FFMPEG path:           /usr/bin/ffmpeg
2020/03/02 17:11:02 [xTeVe] Streaming URL:
2020/03/02 17:11:02 [xTeVe] FFMPEG:                Processing data
2020/03/02 17:11:02 [xTeVe] Streaming Status:      Receive data from FFMPEG
2020/03/02 17:11:02 [xTeVe] FFMPEG log:            : No such file or directory
2020/03/02 17:11:02 [xTeVe] [ERROR] FFMPEG error (Streaming was stopped by third party transcoder (FFmpeg / VLC)) - EC: 1204                                               2020/03/02 17:11:02 [xTeVe] Streaming Status:      Client has terminated the connection
2020/03/02 17:11:02 [xTeVe] Streaming Status:      Channel: Lazystream: NHL 1 (Clients: 0)
2020/03/02 17:11:02 [xTeVe] Streaming Status:      Channel: Lazystream: NHL 1 - No client is using this channel anymore. Streaming Server connection has ended
2020/03/02 17:11:02 [xTeVe] Streaming Status:      Playlist: nhl - Tuner: 0 / 4
```