### PR TITLE
bump lazystream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
 
 # Add lazystream
-RUN wget https://github.com/tarkah/lazystream/releases/download/v1.9.7/lazystream-v1.9.7-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.9.8/lazystream-v1.9.8-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv lazystream/lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \


### PR DESCRIPTION
has xmltv fixes

- Create records for ALL games scheduled for the day, even
    if the stream doesn't exist yet.
- Update programme start time to be accurate

