### PR TITLE
update lazystream for mlb bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
 
 # Add lazystream
-RUN wget https://github.com/tarkah/lazystream/releases/download/v1.9.8/lazystream-v1.9.8-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.10.3/lazystream-v1.10.3-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv lazystream/lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \


### PR DESCRIPTION
Hey! So MLB kicked off and NHL is around the corner and I noticed a bug with my program which I just patched. This PR pulls in the new release.

It appears MLB games aren't being posted to the proxy server anymore (LazyMan shut down?), but the proxy server is still up and you can fetch old NHL games still. Hopefully NHL playoff games will be posted :crossed_fingers: 