### PR TITLE
Update version of lazystream

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
 
 # Add lazystream
-RUN wget https://github.com/tarkah/lazystream/releases/download/v1.10.3/lazystream-v1.10.3-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.10.4/lazystream-v1.10.4-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv lazystream/lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \


### PR DESCRIPTION
Updating version in order to bring in this update https://github.com/tarkah/lazystream/pull/45 which keeps the streams in a consistent order.