### PR TITLE
Pull xTeve ip from env

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ By default, the cron job is scheduled to run every hour. A custom cron schedule 
 
 ## xTeVe
 
-By default, xTeVe is setup with all 200 channels mapped for NHL and MLB games. This can be setup directly with Plex / Emby to work out of the box without any changes. If needed, changes can be made to xTeVe by going to `127.0.0.1:34400/web/`.
+By default, xTeVe is setup with all 200 channels mapped for NHL and MLB games. This can be setup directly with Plex / Emby to work out of the box without any changes. If needed, changes can be made to xTeVe by going to `<xTeVe IP>:34400/web/`.
 
 ## guide2go
 

--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -55,11 +55,11 @@ sleep 1
 # update xteve via API
 if [ "$use_xTeveAPI" = "yes" ]; then
 	echo "Updating xTeVe..."
-	curl -s -X POST -d '{"cmd":"update.m3u"}' http://127.0.0.1:$XTEVE_PORT/api/
+	curl -s -X POST -d '{"cmd":"update.m3u"}' http://$xTeveIP:$XTEVE_PORT/api/
 	sleep 1
-	curl -s -X POST -d '{"cmd":"update.xmltv"}' http://127.0.0.1:$XTEVE_PORT/api/
+	curl -s -X POST -d '{"cmd":"update.xmltv"}' http://$xTeveIP:$XTEVE_PORT/api/
 	sleep 1
-	curl -s -X POST -d '{"cmd":"update.xepg"}' http://127.0.0.1:$XTEVE_PORT/api/
+	curl -s -X POST -d '{"cmd":"update.xepg"}' http://$xTeveIP:$XTEVE_PORT/api/
 	sleep 1
 fi
 

--- a/sample.env
+++ b/sample.env
@@ -6,6 +6,7 @@ PGID=1000
 
 ### Xteve Config
 XTEVE_PORT=34400
+xTeveIP=
 use_xTeveAPI=yes
 
 ### Lazystream Config


### PR DESCRIPTION
Looks like we weren't pulling the xTeve IP from the environment variables – not sure when this happened @tarkah but may have just been an oversight. Has been working since my original `cronjob` was still in place.

edit – updated the readme as well, I think this was just an oversight.. we shouldn't assume the IP of xTeVe, right?