### PR TITLE
Update guide2go

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ By default, xTeVe is setup with all 200 channels mapped for NHL and MLB games. T
 
 ## guide2go
 
-If you have an existing guide2go setup you may copy the `.json` files into the path mounted at `/guide2go`. Otherwise run the following command and follow the on-screen steps  
-`docker exec -it dockername guide2go -configure /guide2go/your_epg_name.json`
+If you have an existing guide2go setup you may copy the `.yaml` files into the path mounted at `/guide2go`. Otherwise run the following command and follow the on-screen steps  
+`docker exec -it dockername guide2go -configure /guide2go/your_epg_name.yaml`
 
 ## Testing cronjob function
 


### PR DESCRIPTION
Updates the `guide2go` binary from `1.0.6` -> `1.1.2`. Note this is a breaking change in that users will have to regenerate their guide2go config. @tarkah figured I'd just add you as an official collaborator, not sure why I never did that before. This is really my first public repo that anyone cared about. Let me know if you think I should call this change out anywhere else like the readme or whatever. Not sure how many people are actually using guide2go.

resolves #19 