### PR TITLE
Add updated instructions for automagically updating Plex

### DIFF
--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -94,7 +94,7 @@ if [ "$use_plexAPI" = "yes" ]; then
 	if [ -z "$plexIP" ]; then
 		echo "no Plex credentials provided"
 	else
-		curl -s -X POST "http://$plexIP:$plexPORT/livetv/dvrs/$plexID/reloadGuide?X-Plex-Token=$plexToken"
+		curl -s -X POST "$plexUpdateURL"
 		sleep 1
 	fi
 fi

--- a/sample.env
+++ b/sample.env
@@ -37,10 +37,10 @@ embyID=
 
 ### Plex
 # Only necessary if xTeVe API is active
-# Finding your Plex token: https://support.plex.tv/articles/204059436-finding-an-authentication-token-x-plex-token/
-# Finding Plex ID: http://YOUR_IP_HERE:32400/?X-Plex-Token=YOUR_TOKEN_HERE , look for "tv.plex.providers.epg.xmltv:  " and enter the value blow.
-use_plexAPI=no
-plexIP=
-plexPORT=32400
-plexToken=
-plexID=
+# To find your Plex Update URL navigate to your plex server in chrome (eg, 192.168.1.1:32400/web/), 
+# and open chrome developer tools (press F12). Once developer tools is open find and click the "Refresh 
+# Guide" link in Plex and then look at the developer tools window. The first request listed should start
+# with "reloadGuide?". Right click the line and go to copy -> Copy link address. Paste the result below as
+# plexUpdateURL. 
+
+plexUpdateURL=


### PR DESCRIPTION
So the URL we were using to update Plex was I believe out of date – it for sure wasn't working for me. I found this method of grabbing the URL to post to by just inspecting the network tab while making the request in the browser. Let me know what you think – may as well get your input!