### PR TITLE
Fixed Plex DVR refresh variables

### DIFF
--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -91,7 +91,7 @@ fi
 # update Plex via API
 if [ "$use_plexAPI" = "yes" ]; then
 	echo "Updating Plex..."
-	if [ -z "$plexIP" ]; then
+	if [ -z "$plexUpdateURL" ]; then
 		echo "no Plex credentials provided"
 	else
 		curl -s -X POST "$plexUpdateURL"

--- a/sample.env
+++ b/sample.env
@@ -42,5 +42,5 @@ embyID=
 # Guide" link in Plex and then look at the developer tools window. The first request listed should start
 # with "reloadGuide?". Right click the line and go to copy -> Copy link address. Paste the result below as
 # plexUpdateURL. 
-
+use_plexAPI=no
 plexUpdateURL=


### PR DESCRIPTION
I just started setting up this container and noticed that the plex guide refresh step wasn't running from the cronjob. I updated the conditional check in the `cronjob.sh` file and added `use_plexAPI` to the `sample.env`.

Tested it by just running the `cronjob.sh` script manually and verifying that plex DVR was refreshing in the UI seen below:
![image](https://user-images.githubusercontent.com/8650838/111253744-140a6880-85ea-11eb-8f2c-cdd97529b549.png)
