### PR TITLE
fix permissions issue for xteve auto update

### DIFF
--- a/root/etc/cont-init.d/60-chown-files
+++ b/root/etc/cont-init.d/60-chown-files
@@ -7,3 +7,6 @@ chown -R abc:abc /xteve
 chown -R abc:abc /tmp/xteve
 
 chown -R abc:abc /home/abc
+
+# So xteve can auto update
+chown -R abc:abc /usr/bin


### PR DESCRIPTION
resolves #43 

I haven't tested as the xteve auto update time is seemingly random (and this now pulls the latest version -___-). But this _should_ work