### PR TITLE
Add aarch64 support and Channels DVR support

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf

--- a/Dockerfile-aarch64
+++ b/Dockerfile-aarch64
@@ -1,0 +1,85 @@
+FROM alpine:latest
+
+LABEL maintainer="taylorbourne taylorbourne@me.com.com"
+
+# Install S6 overlay
+ARG S6_OVERLAY_RELEASE=https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-amd64.tar.gz
+ENV S6_OVERLAY_RELEASE=${S6_OVERLAY_RELEASE}
+
+ADD ${S6_OVERLAY_RELEASE} /tmp/s6overlay.tar.gz
+
+RUN tar xzf /tmp/s6overlay.tar.gz -C / \
+    && rm /tmp/s6overlay.tar.gz
+
+# Add packages
+RUN apk upgrade --update --no-cache \
+    && apk add --no-cache \
+            ca-certificates \
+            curl \
+            tzdata \
+            bash \
+            coreutils \
+            shadow \
+            ffmpeg \
+            vlc \
+            gnutls-utils
+                       
+# Update Timezone
+ENV TZ=America/Los_Angeles
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# Add xTeve and guide2go
+RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
+
+# Add lazystream
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.4/lazystream-v1.11.4-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+    tar xzf lazystream.tar.gz; \
+    mv ././lazystream /usr/bin/lazystream; \
+    rm lazystream.tar.gz; \
+    rm -rf lazystream/
+
+# Add abc user
+RUN groupmod -g 1000 users && \
+    useradd -u 911 -U -d /home/abc -s /bin/bash abc && \
+    usermod -G users abc
+
+# Copy root folder
+COPY root/ /
+
+# Volumes
+VOLUME /config
+VOLUME /playlists
+VOLUME /guide2go
+VOLUME /xteve
+VOLUME /tmp/xteve
+
+# Set executable permissions
+RUN chmod +x /usr/bin/lazystream
+RUN chmod +x /usr/bin/xteve
+RUN chmod +x /usr/bin/guide2go
+
+# Build arg
+ARG XTEVE_PORT=34400
+
+# Env
+ENV PUID=1000 \
+    PGID=1000 \
+    XTEVE_PORT=${XTEVE_PORT} \
+    use_xTeveAPI=yes \
+    use_lazystream=yes \
+    include_nhl=yes\
+    include_mlb=yes \
+    cdn=akc \
+    use_guide2go=no \
+    YamlList="CBLguide.yaml SATguide.yaml SATSport.yaml" \
+    use_embyAPI=no \
+    embyIP= \ 
+    embyPORT=8096 \
+    embyApiKey= \
+    embyID= \
+    use_plexAPI=no
+
+# Expose Port
+EXPOSE ${XTEVE_PORT}
+
+ENTRYPOINT [ "/init" ]

--- a/Dockerfile-aarch64
+++ b/Dockerfile-aarch64
@@ -1,9 +1,9 @@
-FROM alpine:latest
+FROM arm64v8/alpine:latest
 
 LABEL maintainer="taylorbourne taylorbourne@me.com.com"
 
 # Install S6 overlay
-ARG S6_OVERLAY_RELEASE=https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-amd64.tar.gz
+ARG S6_OVERLAY_RELEASE=https://github.com/just-containers/s6-overlay/releases/latest/download/s6-overlay-aarch64.tar.gz
 ENV S6_OVERLAY_RELEASE=${S6_OVERLAY_RELEASE}
 
 ADD ${S6_OVERLAY_RELEASE} /tmp/s6overlay.tar.gz
@@ -23,16 +23,26 @@ RUN apk upgrade --update --no-cache \
             ffmpeg \
             vlc \
             gnutls-utils
+
+# pi4 library to run lazystream: https://github.com/ljfranklin/alpine-pkg-glibc/releases/tag/2.32-r0-arm64
+RUN wget https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/glibc-2.32-r0.apk
+RUN apk add --allow-untrusted glibc-2.32-r0.apk
+
+RUN wget https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/glibc-bin-2.32-r0.apk
+RUN apk add --allow-untrusted glibc-bin-2.32-r0.apk
+
+RUN wget https://github.com/ljfranklin/alpine-pkg-glibc/releases/download/2.32-r0-arm64/glibc-i18n-2.32-r0.apk
+RUN apk add --allow-untrusted glibc-i18n-2.32-r0.apk
                        
 # Update Timezone
 ENV TZ=America/Los_Angeles
 RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 
 # Add xTeve and guide2go
-RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
+RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_arm64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
 
 # Add lazystream
-RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.4/lazystream-v1.11.4-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.4/lazystream-v1.11.4-aarch64-unknown-linux-gnu.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv ././lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \

--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -99,4 +99,21 @@ if [ "$use_plexAPI" = "yes" ]; then
 	fi
 fi
 
+# update Channels via API
+if [ "$use_channelsAPI" = "yes" ]; then
+	echo "Updating Channels..."
+	if [ -z "$channelsUpdateM3uURL" ]; then
+		echo "no Channels M3U URL provided"
+	else
+		curl -s -X POST "$channelsUpdateM3uURL"
+		sleep 1
+	fi
+	if [ -z "$channelsUpdateXmltvURL" ]; then
+		echo "no Channels XMLTV URL provided"
+	else
+		curl -s -X PUT "$channelsUpdateXmltvURL"
+		sleep 1
+	fi
+fi
+
 exit

--- a/sample.env
+++ b/sample.env
@@ -52,7 +52,7 @@ plexUpdateURL=
 # M3U" and "Refresh XMLTV" links in Channels and then look at the developer tools window. Right click the line and 
 # go to copy -> Copy link address. URL examples:
 # channelsUpdateM3uURL -> http://192.168.1.1:8089/providers/m3u/sources/<source name>/refresh
-# channelsUpdateXmltvURL -> http://192.168.1.37:8089/dvr/lineups/XMLTV-<source name>
+# channelsUpdateXmltvURL -> http://192.168.1.1:8089/dvr/lineups/XMLTV-<source name>
 use_channelsAPI=no
 channelsUpdateM3uURL=
 channelsUpdateXmltvURL=

--- a/sample.env
+++ b/sample.env
@@ -44,3 +44,15 @@ embyID=
 # plexUpdateURL. 
 use_plexAPI=no
 plexUpdateURL=
+
+### Channels DVR
+# Only necessary if xTeVe API is active
+# To find your Channels Update URL navigate to your Channels server in chrome (eg, http://192.168.1.1:8089), 
+# and open chrome developer tools (press F12). Once developer tools is open find and click the "Refresh 
+# M3U" and "Refresh XMLTV" links in Channels and then look at the developer tools window. Right click the line and 
+# go to copy -> Copy link address. URL examples:
+# channelsUpdateM3uURL -> http://192.168.1.1:8089/providers/m3u/sources/<source name>/refresh
+# channelsUpdateXmltvURL -> http://192.168.1.37:8089/dvr/lineups/XMLTV-<source name>
+use_channelsAPI=no
+channelsUpdateM3uURL=
+channelsUpdateXmltvURL=


### PR DESCRIPTION
For the new Dockerfile, I committed the original in a separate commit so that you can see a diff of the changes here: https://github.com/taylorbourne/xteve_lazystream/commit/13f264d7bbbabae235a4eef0d92a75d2ccf0a36f

I am not sure if anyone else has the same use case as me, but these changes allow me to run the new Docker image on a Raspberry Pi 4. I am using a forked version of the glibc package with aarch64 support - found via this open issue on the main repo: https://github.com/sgerrand/alpine-pkg-glibc/issues/113

I also added Channels DVR support, which has the same M3U/custom DVR functionality as Plex.