### PR TITLE
Update Aarch64 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,17 +4,17 @@ This Docker provides a simple solution to get live NHL and MLB games into your E
 
 - [Run](#run)
 - [Setup](#setup)
-	- [Env file](#env-file)
-	- [Cron schedule](#cron-schedule)
-	- [Sample volume mapping](#sample-volume-mapping)
-	- [xTeVe](#xteve)
-	- [guide2go](#guide2go)
-	- [Testing cronjob function](#testing-cronjob-function)
-	- [Notes on Channels DVR](#notes-on-channels-dvr)
+  - [Env file](#env-file)
+  - [Cron schedule](#cron-schedule)
+  - [Sample volume mapping](#sample-volume-mapping)
+  - [xTeVe](#xteve)
+  - [guide2go](#guide2go)
+  - [Testing cronjob function](#testing-cronjob-function)
+  - [Notes on Channels DVR](#notes-on-channels-dvr)
 - [Credits](#credits)
-	- [guide2go](#guide2go-1)
-	- [Lazystream](#lazystream)
-	- [xTeVe](#xteve-1)
+  - [guide2go](#guide2go-1)
+  - [Lazystream](#lazystream)
+  - [xTeVe](#xteve-1)
 
 # Run
 
@@ -71,8 +71,11 @@ Simply run the cronjob file inside the Docker container
 `docker exec -it dockername ./cronjob.sh`
 
 ## Notes On Channels DVR
-* You have to select MPEG-TS as the stream format
-* The stream only works in a browser - not on Android TV or Android
+
+- You have to select MPEG-TS as the stream format
+- The stream only works in a browser - not on Android TV or Android
+- Adding an m3u playlist to Channels:
+  https://getchannels.com/docs/channels-dvr-server/how-to/custom-channels/#adding-your-custom-channels
 
 # Credits
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This Docker provides a simple solution to get live NHL and MLB games into your E
 	- [xTeVe](#xteve)
 	- [guide2go](#guide2go)
 	- [Testing cronjob function](#testing-cronjob-function)
+	- [Notes on Channels DVR](#notes-on-channels-dvr)
 - [Credits](#credits)
 	- [guide2go](#guide2go-1)
 	- [Lazystream](#lazystream)
@@ -68,6 +69,10 @@ If you have an existing guide2go setup you may copy the `.yaml` files into the p
 
 Simply run the cronjob file inside the Docker container  
 `docker exec -it dockername ./cronjob.sh`
+
+## Notes On Channels DVR
+* You have to select MPEG-TS as the stream format
+* The stream only works in a browser - not on Android TV or Android
 
 # Credits
 

--- a/root/etc/cont-init.d/60-update-lazystream
+++ b/root/etc/cont-init.d/60-update-lazystream
@@ -11,7 +11,7 @@ exec 1> >(prepend "[update-lazystream] ")
 echo "checking for update"
 
 current_version=$(lazystream --version)
-current_version=v${current_version:11}
+current_version=v1.11.3
 
 echo "installed version: ${current_version}"
 
@@ -20,10 +20,14 @@ latest_version=$(echo $latest_release | grep -oE 'v[0-9]+\.[0-9]+\.[0-9]+' | hea
 
 echo "remote version: ${latest_version}"
 
+[ "$(arch)" == "x86_64" ] && release_name=$lazyStreamReleaseName || release_name=$lazyStreamReleaseNameAarch64
+
+echo "https://github.com/tarkah/lazystream/releases/download/$latest_version/lazystream-$latest_version-$release_name.tar.gz"
+
 if [ $current_version != $latest_version ]; then
     echo "newer version available, downloading..."
 
-    wget https://github.com/tarkah/lazystream/releases/download/$latest_version/lazystream-$latest_version-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+    wget https://github.com/tarkah/lazystream/releases/download/$latest_version/lazystream-$latest_version-$release_name.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv ././lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \

--- a/root/etc/cont-init.d/60-update-lazystream
+++ b/root/etc/cont-init.d/60-update-lazystream
@@ -11,7 +11,7 @@ exec 1> >(prepend "[update-lazystream] ")
 echo "checking for update"
 
 current_version=$(lazystream --version)
-current_version=v1.11.3
+current_version=v${current_version:11}
 
 echo "installed version: ${current_version}"
 

--- a/root/etc/cont-init.d/60-update-lazystream
+++ b/root/etc/cont-init.d/60-update-lazystream
@@ -22,8 +22,6 @@ echo "remote version: ${latest_version}"
 
 [ "$(arch)" == "x86_64" ] && release_name=$lazyStreamReleaseName || release_name=$lazyStreamReleaseNameAarch64
 
-echo "https://github.com/tarkah/lazystream/releases/download/$latest_version/lazystream-$latest_version-$release_name.tar.gz"
-
 if [ $current_version != $latest_version ]; then
     echo "newer version available, downloading..."
 

--- a/sample.env
+++ b/sample.env
@@ -56,3 +56,10 @@ plexUpdateURL=
 use_channelsAPI=no
 channelsUpdateM3uURL=
 channelsUpdateXmltvURL=
+
+### LazyStream Release Names
+# ** WARNING **
+# If you change these values you're on your own! There's really no need to change anything here unless
+# your unique setup calls for it.
+lazyStreamReleaseName=x86_64-unknown-linux-musl
+lazyStreamReleaseNameAarch64=aarch64-unknown-linux-gnu


### PR DESCRIPTION
Updates the auto update check for LazyStream to set the right download URL based on architecture. Since we added the aarch64 Docker file we may as well make sure it's properly supported. I'm not sure that the release names need to be configurable, I just figured why not.

@nkm8 if you could, let me know how to expand on the readme updates for Channels DVR since I'm not really familiar with it.