### PR TITLE
Add env variables to exclude certain nhl feeds

### DIFF
--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -30,6 +30,12 @@ if [ "$use_lazystream" = "yes" ]; then
 		nhl_args+=("1000")
 		nhl_args+=("/playlists/lazystream/lazystream-nhl")
 
+		if [ "$nhl_exclude_home" = "yes" ]; 	 then nhl_args+=("--exclude-feeds" "HOME"); fi
+		if [ "$nhl_exclude_away" = "yes" ]; 	 then nhl_args+=("--exclude-feeds" "AWAY"); fi
+		if [ "$nhl_exclude_national" = "yes" ];  then nhl_args+=("--exclude-feeds" "NATIONAL"); fi
+		if [ "$nhl_exclude_french" = "yes" ]; 	 then nhl_args+=("--exclude-feeds" "FRENCH"); fi
+		if [ "$nhl_exclude_composite" = "yes" ]; then nhl_args+=("--exclude-feeds" "COMPOSITE"); fi
+
 		lazystream generate xmltv "${args[@]}" "${nhl_args[@]}"
 	fi
 	if [ "$include_mlb" = "yes" ]; then

--- a/sample.env
+++ b/sample.env
@@ -14,6 +14,11 @@ include_nhl=yes
 include_mlb=yes
 cdn=akc
 #quality=720p60
+#nhl_exclude_home=yes
+#nhl_exclude_away=yes
+#nhl_exclude_national=yes
+#nhl_exclude_french=yes
+#nhl_exclude_composite=yes
 
 ### Guide2go Config
 use_guide2go=no


### PR DESCRIPTION
Added a few environment variables to exclude certain NHL feeds from lazystream xmltv generation. Helps to reduce clutter for streams I will never watch.

I assume something similar would also work for MLB, too.