### PR TITLE
Version bump on lazystream to fix NHL API change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
 
 # Add lazystream
-RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.4/lazystream-v1.11.4-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.5/lazystream-v1.11.5-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv ././lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \

--- a/Dockerfile-aarch64
+++ b/Dockerfile-aarch64
@@ -42,7 +42,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_arm64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
 
 # Add lazystream
-RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.4/lazystream-v1.11.4-aarch64-unknown-linux-gnu.tar.gz -O lazystream.tar.gz; \
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.5/lazystream-v1.11.5-aarch64-unknown-linux-gnu.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv ././lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \


### PR DESCRIPTION
In response to this issue fix: https://github.com/tarkah/lazystream/issues/73

I tested with `Dockerfile`, not `Dockerfile-aarch64`, but just assumed it should get bumped as well.

**Successful test stream:**
![image](https://user-images.githubusercontent.com/8650838/118746463-4f155c00-b826-11eb-83e1-8f3aeccbdbb5.png)
