### PR TITLE
Add options to exclude feeds

### DIFF
--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -30,6 +30,12 @@ if [ "$use_lazystream" = "yes" ]; then
 		nhl_args+=("1000")
 		nhl_args+=("/playlists/lazystream/lazystream-nhl")
 
+		if [ "$nhl_exclude_home" = "yes" ]; 	 then nhl_args+=("--exclude-feeds" "HOME"); fi
+		if [ "$nhl_exclude_away" = "yes" ]; 	 then nhl_args+=("--exclude-feeds" "AWAY"); fi
+		if [ "$nhl_exclude_national" = "yes" ];  then nhl_args+=("--exclude-feeds" "NATIONAL"); fi
+		if [ "$nhl_exclude_french" = "yes" ]; 	 then nhl_args+=("--exclude-feeds" "FRENCH"); fi
+		if [ "$nhl_exclude_composite" = "yes" ]; then nhl_args+=("--exclude-feeds" "COMPOSITE"); fi
+
 		lazystream generate xmltv "${args[@]}" "${nhl_args[@]}"
 	fi
 	if [ "$include_mlb" = "yes" ]; then
@@ -45,6 +51,11 @@ if [ "$use_lazystream" = "yes" ]; then
 		mlb_args+=("--start-channel")
 		mlb_args+=("2000")
 		mlb_args+=("/playlists/lazystream/lazystream-mlb")
+
+		if [ "$mlb_exclude_home" = "yes" ]; 	 then mlb_args+=("--exclude-feeds" "HOME"); fi
+		if [ "$mlb_exclude_away" = "yes" ]; 	 then mlb_args+=("--exclude-feeds" "AWAY"); fi
+		if [ "$mlb_exclude_national" = "yes" ];  then mlb_args+=("--exclude-feeds" "NATIONAL"); fi
+		if [ "$mlb_exclude_composite" = "yes" ]; then mlb_args+=("--exclude-feeds" "COMPOSITE"); fi
 
 		lazystream generate xmltv "${args[@]}" "${mlb_args[@]}"
 	fi

--- a/sample.env
+++ b/sample.env
@@ -11,7 +11,16 @@ use_xTeveAPI=yes
 ### Lazystream Config
 use_lazystream=yes
 include_nhl=yes
+#nhl_exclude_home=yes
+#nhl_exclude_away=yes
+#nhl_exclude_national=yes
+#nhl_exclude_french=yes
+#nhl_exclude_composite=yes
 include_mlb=yes
+#mlb_exclude_home=yes
+#mlb_exclude_away=yes
+#mlb_exclude_national=yes
+#mlb_exclude_composite=yes
 cdn=akc
 #quality=720p60
 


### PR DESCRIPTION
Based on the work of @calculon7 – adds some options to exclude feeds for both MLB and NHL.

@tarkah I got rid of the French option for MLB, does composite still apply?