### PR TITLE
fix: fix plex update request

### DIFF
--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -107,7 +107,7 @@ if [ "$use_plexAPI" = "yes" ]; then
 	if [ -z "$plexUpdateURL" ]; then
 		echo "no Plex credentials provided"
 	else
-		$(echo "$plexUpdateURL" | tr -d '\n' | tr -d ' ')
+		$(echo "$plexUpdateUrl" | sed 's/\\/ /g' | sed "s/'/\"/g")
 		sleep 1
 	fi
 fi

--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -107,7 +107,7 @@ if [ "$use_plexAPI" = "yes" ]; then
 	if [ -z "$plexUpdateURL" ]; then
 		echo "no Plex credentials provided"
 	else
-		"$plexUpdateURL"
+		$(echo "$plexUpdateURL" | tr -d '\n' | tr -d ' ')
 		sleep 1
 	fi
 fi

--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -107,7 +107,7 @@ if [ "$use_plexAPI" = "yes" ]; then
 	if [ -z "$plexUpdateURL" ]; then
 		echo "no Plex credentials provided"
 	else
-		curl -s -X POST "$plexUpdateURL"
+		"$plexUpdateURL"
 		sleep 1
 	fi
 fi

--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -107,7 +107,7 @@ if [ "$use_plexAPI" = "yes" ]; then
 	if [ -z "$plexUpdateURL" ]; then
 		echo "no Plex credentials provided"
 	else
-		$(echo "$plexUpdateUrl" | sed 's/\\/ /g' | sed "s/'/\"/g")
+		curl --location --request POST "$plexUpdateURL"
 		sleep 1
 	fi
 fi

--- a/sample.env
+++ b/sample.env
@@ -41,7 +41,8 @@ YamlList="CBLguide.yaml SATguide.yaml SATSport.yaml"
 ### Emby
 # Only necessary if xTeVe API is active
 # API Key, https://github.com/MediaBrowser/Emby/wiki/Api-Key-Authentication
-# embyID, settings, scroll down click API, Scheduled Task Service, GET /ScheduledTasks, Try, Execute, look for "Refresh Guide" ID, sample here 9492d30c70f7f1bec3757c9d0a4feb45
+# embyID, settings, scroll down click API, Scheduled Task Service, GET /ScheduledTasks, Try, Execute, 
+# look for "Refresh Guide" ID, sample here 9492d30c70f7f1bec3757c9d0a4feb45
 use_embyAPI=no
 embyIP=
 embyPORT=8096
@@ -51,10 +52,10 @@ embyID=
 ### Plex
 # Only necessary if xTeVe API is active
 # To find your Plex Update URL navigate to your plex server in chrome (eg, 192.168.1.1:32400/web/), 
-# and open chrome developer tools (press F12). Once developer tools is open find and click the "Refresh 
-# Guide" link in Plex and then look at the developer tools window. The first request listed should start
-# with "reloadGuide?". Right click the line and go to copy -> Copy link address. Paste the result below as
-# plexUpdateURL. 
+# and open chrome developer tools (press F12). Once developer tools is open, press (Ctrl/Cmd)+Shift+P, 
+# type "network" and press enter. Then, find and click the "Refresh Guide" link in Plex. Over in the 
+# developer tools window/pane, the first request listed should start with "reloadGuide?". Right click 
+# the line and go to copy -> Copy as cURL. Paste the result below as plexUpdateURL. 
 use_plexAPI=no
 plexUpdateURL=
 

--- a/sample.env
+++ b/sample.env
@@ -55,7 +55,7 @@ embyID=
 # and open chrome developer tools (press F12). Once developer tools is open, press (Ctrl/Cmd)+Shift+P, 
 # type "network" and press enter. Then, find and click the "Refresh Guide" link in Plex. Over in the 
 # developer tools window/pane, the first request listed should start with "reloadGuide?". Right click 
-# the line and go to copy -> Copy as cURL. Paste the result below as plexUpdateURL. 
+# the line and go to copy -> Copy link address. Paste the result below as plexUpdateURL. 
 use_plexAPI=no
 plexUpdateURL=
 


### PR DESCRIPTION
Fixes problems seen with Plex not running the guide update when the cronjob runs. ~Something within Plex changed and looks like this needs to be a `POST` request in order to work.~ Got this working in postman by changing up the curl options.

Also made some changes to the sample env docs to make finding the plex URL a bit easier.

@echefel @chesh1r3k @chanrwm

resolves #63 