### PR TITLE
Fixes/host and trim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -78,7 +78,7 @@ ENV PUID=1000 \
     embyApiKey= \
     embyID= \
     use_plexAPI=no \
-    trim_xmltv=yes \
+    trim_xmltv=no \
     hostOverride=
 
 # Expose Port

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 RUN wget https://github.com/xteve-project/xTeVe-Downloads/raw/master/xteve_linux_amd64.zip -O temp.zip; unzip temp.zip -d /usr/bin/; rm temp.zip
 
 # Add lazystream
-RUN wget https://github.com/tarkah/lazystream/releases/download/v1.11.8/lazystream-v1.11.8-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
+RUN wget https://github.com/tarkah/lazystream/releases/download/v1.12.0/lazystream-v1.12.0-x86_64-unknown-linux-musl.tar.gz -O lazystream.tar.gz; \
     tar xzf lazystream.tar.gz; \
     mv ././lazystream /usr/bin/lazystream; \
     rm lazystream.tar.gz; \
@@ -78,7 +78,8 @@ ENV PUID=1000 \
     embyApiKey= \
     embyID= \
     use_plexAPI=no \
-    trim_xmltv=yes
+    trim_xmltv=yes \
+    hostOverride=
 
 # Expose Port
 EXPOSE ${XTEVE_PORT}

--- a/README.md
+++ b/README.md
@@ -42,10 +42,6 @@ or see [docker-compose.yml](docker-compose.yml) for an example docker-compose se
 
 Defaults & behavior can be changed through environment variables. `sample.env` should be renamed to `.env` and supplied through the `--env-file` docker run option. The `.env` file can also be picked up if using this in a `docker compose` setup.
 
-### IMPORTANT
-
-You _MUST_ set the environment variable `lazyStreamHost` otherwise LazyStream will _not_ work.
-
 ## Cron schedule
 
 By default, the cron job is scheduled to run every hour. A custom cron schedule can be specified by renaming the `sample_cron.txt` file in the `/config` volume to `cron.txt` and editing the schedule. Make sure to restart your container to take effect.

--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -19,6 +19,7 @@ if [ "$use_lazystream" = "yes" ]; then
 	if [ "$trim_xmltv" = "yes" ]; then args+=("--trim"); fi
 	if [ ! -z ${quality} ]; then args+=("--quality" "$quality"); fi
 	if [ "$cdn" = "l3c" ]; then args+=("--cdn" "l3c"); fi
+	if [ ! -z "$hostOverride" ]; then args+=("--host" "$hostOverride"); fi
 
 	if [ "$include_nhl" = "yes" ]; then
 		echo "Running Lazystream (NHL $quality via $cdn)..."
@@ -38,7 +39,9 @@ if [ "$use_lazystream" = "yes" ]; then
 		if [ "$nhl_exclude_french" = "yes" ]; 	 then nhl_args+=("--exclude-feeds" "FRENCH"); fi
 		if [ "$nhl_exclude_composite" = "yes" ]; then nhl_args+=("--exclude-feeds" "COMPOSITE"); fi
 
+		set -x
 		lazystream generate xmltv "${args[@]}" "${nhl_args[@]}"
+		set +x
 	fi
 	if [ "$include_mlb" = "yes" ]; then
 		echo "Running Lazystream (MLB $quality via $cdn)..."
@@ -59,7 +62,9 @@ if [ "$use_lazystream" = "yes" ]; then
 		if [ "$mlb_exclude_national" = "yes" ];  then mlb_args+=("--exclude-feeds" "NATIONAL"); fi
 		if [ "$mlb_exclude_composite" = "yes" ]; then mlb_args+=("--exclude-feeds" "COMPOSITE"); fi
 
+		set -x
 		lazystream generate xmltv "${args[@]}" "${mlb_args[@]}"
+		set +x
 	fi
 fi
 

--- a/root/etc/cont-init.d/50-update-hosts
+++ b/root/etc/cont-init.d/50-update-hosts
@@ -10,7 +10,10 @@ exec 1> >(prepend "[update-hosts] ")
 
 
 # Update hosts file
-export IP=$(getent ahostsv4 "$lazyStreamHost" | awk '{ print $1 }' | head -1)
+if [ ! -z "$hostOverride" ]; then lazystream_host="$hostOverride"; else lazystream_host=$(lazystream host); fi
+echo "Using host ${lazystream_host}"
+
+export IP=$(getent ahostsv4 $(echo $lazystream_host | sed -e 's/https*:\/\///g') | awk '{ print $1 }' | head -1)
 
 echo $IP playback.svcs.mlb.com >> /etc/hosts
 echo $IP mf.svc.nhl.com >> /etc/hosts

--- a/sample.env
+++ b/sample.env
@@ -9,10 +9,10 @@ XTEVE_PORT=34400
 use_xTeveAPI=yes
 
 ### Lazystream Config
-# If trim_xmltv is set to no, both NHL and MLB will output 100 placeholder channels each.
-# Any unused channels will still display in your guide. Disable this feature if you have
-# any trouble with Plex/Emby/etc. guide data.
-trim_xmltv=yes
+# If trim_xmltv is set to yes, both NHL and MLB wont output 100 placeholder channels and
+# will instead only output the same number of channels as there are streams.
+# Enabling this feature may cause issues with xTeVe guide data.
+trim_xmltv=no
 use_lazystream=yes
 include_nhl=yes
 #nhl_exclude_home=yes

--- a/sample.env
+++ b/sample.env
@@ -27,6 +27,8 @@ include_mlb=yes
 #mlb_exclude_composite=yes
 cdn=akc
 #quality=720p60
+# This will override the default host used by lazystream. Use in case host changes.
+#hostOverride=http://yourhost.here
 
 ### Guide2go Config
 use_guide2go=no

--- a/xteve_lazystream.xml
+++ b/xteve_lazystream.xml
@@ -172,7 +172,7 @@
   <Config Name="Path" Target="/playlists" Default="/mnt/user/appdata/xteve/playlists/" Mode="rw" Description="Container Path: /playlists" Type="Path" Display="always" Required="false" Mask="false">/mnt/user/appdata/xteve/playlists/</Config>
   <Config Name="Xteve API" Target="use_xTeveAPI" Default="yes" Mode="" Description="Container Variable: use_xTeveAPI" Type="Variable" Display="always" Required="false" Mask="false">yes</Config>
   <Config Name="Use Lazystream" Target="use_lazystream" Default="yes" Mode="" Description="Container Variable: use_lazystream" Type="Variable" Display="always" Required="false" Mask="false">yes</Config>
-  <Config Name="Lazystream Host" Target="lazystream_host" Default="" Mode="" Description="Container Variable: lazyStreamHost" Type="Variable" Display="always" Required="false" Mask="false"/>
+  <Config Name="Lazystream Host Override" Target="hostOverride" Default="" Mode="" Description="Container Variable: hostOverride" Type="Variable" Display="always" Required="false" Mask="false"/>
   <Config Name="Trim XMLTV" Target="trim_xmltv" Default="yes" Mode="" Description="Container Variable: trim_xmltv" Type="Variable" Display="always" Required="false" Mask="false">yes</Config>
   <Config Name="Include NHL" Target="include_nhl" Default="yes" Mode="" Description="Container Variable: include_nhl" Type="Variable" Display="always" Required="false" Mask="false">yes</Config>
   <Config Name="include MLB" Target="include_mlb" Default="yes" Mode="" Description="Container Variable: include_mlb" Type="Variable" Display="always" Required="false" Mask="false">yes</Config>


### PR DESCRIPTION
This PR makes 2 changes:

1. Uses the new `--host` and `host` flags for `lazystream` to better setup a host override. The variable `hostOverride`, if set, will update the host used by `lazystream` and the hosts file update in the docker container. This provides a more robust implementation over #72 
2. Make `trim_xmltv` default to no. I don't think having it as a default is good practice, as it's a breaking change and I don't believe reliable at all w/ xTeVe.