### PR TITLE
fix: attempt to fix plex guide refresh

### DIFF
--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -88,11 +88,11 @@ sleep 1
 if [ "$use_xTeveAPI" = "yes" ]; then
 	echo "Updating xTeVe..."
 	curl -s -X POST -d '{"cmd":"update.m3u"}' http://127.0.0.1:$XTEVE_PORT/api/
+	# sleep 1
+	curl -s -X POST -d '{"cmd":"update.xmltv"}' http://$127.0.0.1:$XTEVE_PORT/api/
 	sleep 1
-	curl -s -X POST -d '{"cmd":"update.xmltv"}' http://127.0.0.1:$XTEVE_PORT/api/
-	sleep 1
-	curl -s -X POST -d '{"cmd":"update.xepg"}' http://127.0.0.1:$XTEVE_PORT/api/
-	sleep 1
+	curl -s -X POST -d '{"cmd":"update.xepg"}' http://$127.0.0.1:$XTEVE_PORT/api/
+	sleep 30
 fi
 
 # update Emby via API
@@ -108,11 +108,19 @@ fi
 
 # update Plex via API
 if [ "$use_plexAPI" = "yes" ]; then
+	
+	# get protocol
+	proto="$(echo $plexUpdateURL | grep :// | sed -e's,^\(.*://\).*,\1,g')"
+	# remove the protocol
+	url="$(echo ${plexUpdateURL/$proto/})"
+	# extract the host
+	plexHostPort="$(echo ${url/} | cut -d/ -f1)"
+	
 	echo "Updating Plex..."
 	if [ -z "$plexUpdateURL" ]; then
 		echo "no Plex credentials provided"
 	else
-		curl -s -X POST "$plexUpdateURL"
+		curl --location --request POST "$plexUpdateURL" -H "authority: $plexHostPort" -H "content-length: 0" -H "pragma: no-cache" -H "cache-control: no-cache" -H "sec-ch-ua: 'Google Chrome';v='95', 'Chromium';v='95', ';Not A Brand';v='99'" -H "accept: text/plain, */*; q=0.01" -H "x-requested-with: XMLHttpRequest" -H "accept-language: en" -H "sec-ch-ua-mobile: ?0" -H "user-agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/95.0.4638.69 Safari/537.36" -H "sec-ch-ua-platform: 'macOS'" -H "origin: http://$plexHostPort" -H "sec-fetch-site: same-origin" -H "sec-fetch-mode: cors" -H "sec-fetch-dest: empty" -H "referer: http://$plexHostPort/web/index.html"
 		sleep 1
 	fi
 fi


### PR DESCRIPTION
So I took another look at the Plex guide refresh problem quickly today ahead of the games and basically found out that it's a race condition. xTeVe reports that it's M3U/XML updates are successful but is still making changes to the xml file in the background. When we ask plex to run a guide refresh the XML file either isn't ready at all, or maybe a couple of entries have been added.. Thus, you get `Unknown Airing` for all or a majority of your channels.

I'm not sure what we can do to fix this quickly (aside from waiting on my fork of Xteve, which could take months), so I'm just adding a sleep here of 30 seconds which on my end is more than enough to wait for the updates to finish before asking Plex to pick things up.

If anyone has any better ideas I'm open to them, but for now this seems to work. Please give the `develop` tag a try and let me know if you see any issues. Like I said, after running the cronjob a few times on my end it seems to work much more reliably.

@tarkah adding you as a review because you always keep me honest, but I'll leave this open for a while to see if anyone wants to give this a try or chime in before we merge.

@echefel @chesh1r3k – please give this a try!!

Note – I also updated the curl request we make to plex so that there's a 1:1 match with what happens when you request a guide update from the web ui.