### PR TITLE
Fix variable substitution on 127.0.0.1

### DIFF
--- a/root/cronjob.sh
+++ b/root/cronjob.sh
@@ -89,9 +89,9 @@ if [ "$use_xTeveAPI" = "yes" ]; then
 	echo "Updating xTeVe..."
 	curl -s -X POST -d '{"cmd":"update.m3u"}' http://127.0.0.1:$XTEVE_PORT/api/
 	# sleep 1
-	curl -s -X POST -d '{"cmd":"update.xmltv"}' http://$127.0.0.1:$XTEVE_PORT/api/
+	curl -s -X POST -d '{"cmd":"update.xmltv"}' http://127.0.0.1:$XTEVE_PORT/api/
 	sleep 1
-	curl -s -X POST -d '{"cmd":"update.xepg"}' http://$127.0.0.1:$XTEVE_PORT/api/
+	curl -s -X POST -d '{"cmd":"update.xepg"}' http://127.0.0.1:$XTEVE_PORT/api/
 	sleep 30
 fi
 


### PR DESCRIPTION
The `$` seem to be a typo that's causing hangs during startup.